### PR TITLE
Adds Paged Directory Queries for supporting large file throughput

### DIFF
--- a/src/router/router_server_files.go
+++ b/src/router/router_server_files.go
@@ -78,7 +78,7 @@ func getServerFileContents(c *gin.Context) {
 func getServerListDirectory(c *gin.Context) {
 	s := ExtractServer(c)
 	dir := c.Query("directory")
-	if stats, err := s.Filesystem().ListDirectory(dir); err != nil {
+	if stats, err := s.Filesystem().ListDirectory(c.Request.Context(), dir); err != nil {
 		middleware.CaptureAndAbort(c, err)
 	} else {
 		c.JSON(http.StatusOK, stats)


### PR DESCRIPTION
This is an update that will work with a Pyrodactyl update currently being worked on for better file container handling.

## Important:
These changes still works with older versions of the panel and supports both the Legacy version (which I have no removed unneeded called to Mimetype which tanked performance) and the New Paged Version.

Should be a safe merge without any issues to existing clients.